### PR TITLE
hard-code new css height for flex box, temp fix

### DIFF
--- a/arches/app/templates/views/graph/function-manager.htm
+++ b/arches/app/templates/views/graph/function-manager.htm
@@ -32,7 +32,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endblock graph_header_buttons %}
 
 {% block content %}
-<div class="flex">
+<div class="flex" style="height: calc(100vh - 110px)">
 
     <!--Form Listing -->
     <div class="left-column-crud-container form-list">

--- a/arches/app/templates/views/resource/editor.htm
+++ b/arches/app/templates/views/resource/editor.htm
@@ -29,7 +29,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endblock graph_header_buttons %}
 
 {% block content %}
-<div class="flex relative" data-bind="visible: !openRelatedResources()" style="display:none;">
+<div class="flex relative" data-bind="visible: !openRelatedResources()" style="display:none; height: calc(100vh - 110px)">
 
     <!--Form Listing -->
     <div class="left-column-crud-container form-list no-print" data-bind="with: formList">

--- a/arches/app/templates/views/search/search-base-manager.htm
+++ b/arches/app/templates/views/search/search-base-manager.htm
@@ -40,7 +40,7 @@
     </div>
 
     <div class="flex">
-        <div class="flex">
+        <div class="flex" style="height: calc(100vh - 110px)">
 
             <!--Form Listing -->
             <div class="left-column-crud-container search-control-container" data-bind="with: searchResults, css: { 'slide': !resultsExpanded() }">

--- a/arches/app/templates/views/system-settings.htm
+++ b/arches/app/templates/views/system-settings.htm
@@ -24,7 +24,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% endblock graph_header_title %}
 
 {% block content %}
-<div class="flex relative">
+<div class="flex relative" style="height: calc(100vh - 110px)">
 
     <!--Form Listing -->
     <div class="left-column-crud-container form-list" data-bind="with: formList">


### PR DESCRIPTION
Pushing through a fix for a recent issue with the element height of flex elements which had made scrolling impossible.

We'll revisit this issue after v4 has been implemented.

### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
Adds inline css to 4 flexbox elements to explicitly set the height.

### Issues Solved
https://github.com/legiongis/fpan/issues/65