### PR TITLE
5982 optional provisional editing

### DIFF
--- a/arches/app/templates/views/search.htm
+++ b/arches/app/templates/views/search.htm
@@ -42,10 +42,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     }"></div>
 
                     <!--ko if: sharedStateObject.userIsReviewer-->
+                    <!-- Manual Removal of Provisional Edit Filter
                     <div class="qa-filter" data-bind="component: {
                         name: 'provisional-filter',
                         params: sharedStateObject
                     }"></div>
+                    -->
                     <!--/ko-->
 
                 </div>

--- a/arches/app/utils/permission_backend.py
+++ b/arches/app/utils/permission_backend.py
@@ -191,4 +191,9 @@ def user_is_resource_reviewer(user):
     Single test for whether a user is in the Resource Reviewer group
     """
 
-    return user.groups.filter(name='Resource Reviewer').exists()
+    # if provisional editing is disabled, treat all users as resource reviewers
+    if settings.DISABLE_PROVISIONAL_EDITING is True:
+        return True
+    # otherwise check for group membership
+    else:
+        return user.groups.filter(name='Resource Reviewer').exists()

--- a/arches/settings.py
+++ b/arches/settings.py
@@ -500,6 +500,12 @@ MAP_MAX_ZOOM = 20
 # causing your application to break.
 OVERRIDE_RESOURCE_MODEL_LOCK = False
 
+# Set to True if you don't want your application to use provisional editing at
+# all. All editor users will be treated as Resource Reviewers. If set True, you
+# must also make sure to run the following command to disable the Q/A search UI
+#     python manage.py search unregister -n provisional-filter
+DISABLE_PROVISIONAL_EDITING = False
+
 # bounds for search results hex binning fabric (search grid).
 # a smaller bbox will give you less distortion in hexes and better performance
 DEFAULT_BOUNDS = {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Types of changes
<!--- Put an `x` in the boxes that apply  -->
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change
<!--- Include a brief description of this Pull Request and reasoning behind it. -->
This is a working implementation of the solution outlined in this ticket in the core Arches repo: https://github.com/archesproject/arches/issues/5982. The intention is to allow developers to disable provisional editing throughout the application.

It's not as polished as it should be, but it's a start. To implement this, users would have to:

1. make sure there are no lingering provisional edits in the database
2. in settings.py set `DISABLE_PROVISIONAL_EDITING = True`
3. run `python manage.py search unregister -n provisional-filter` to remove the Q/A filter UI from the search page.

Unfortunately, 3. above is not sufficient to remove the UI component, as it's hard-coded into the template. This could be handled by

1. passing the `DISABLE_PROVISIONAL_EDITING` variable to the template and conditionally showing based on that.
2. driving the appearance of the filter in the UI directly from whether the filter has been registered in the database
3. Implementing the "Enable" property of the db object; I tried disabling the filter and it didn't change the UI at all.

All of those methods would be better than what I have right now. I would lean toward 2, as there is no good command-line access currently provided that would allow a user to disable (as opposed to unregister) the provisional-filter.

#### Ticket Background
*   Sponsored by: FPAN
*   Designed by: @mradamcox 
